### PR TITLE
disable-deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:cjs": "tsc --project tsconfig.cjs.json",
     "prepack": "npm run build",
     "deploy": "npm run build-storybook && gh-pages -d storybook-static",
-    "preversion": "npm run clean && npm run build && npm run deploy",
+    "preversion": "npm run clean && npm run build",
     "postversion": "git push && git push --tags && npm publish",
     "format": "prettier --write  --trailing-comma es5 --single-quote 'src/**/*' 'README.MD'",
     "format:check": "prettier --check --trailing-comma es5 --single-quote 'src/**/*' 'README.MD'",


### PR DESCRIPTION
Removed deploy from pre-version as gh-pages command is returning 400. It may be a local issue, best to move this step to GH Actions at some point